### PR TITLE
Add optimisations and numba functionality

### DIFF
--- a/forced_phot/forced_phot.py
+++ b/forced_phot/forced_phot.py
@@ -490,7 +490,7 @@ class ForcedPhot:
                 if i in self.in_cluster:
                     continue
             if self.use_numba:
-                out = self._measure_jit(
+                out = self._numba_measure(
                         X0[i],
                         Y0[i],
                         xmin[i],
@@ -662,7 +662,7 @@ class ForcedPhot:
                 pa[i],
             )
 
-    def _measure_jit(
+    def _numba_measure(
         self,
         X0,
         Y0,
@@ -677,11 +677,11 @@ class ForcedPhot:
         stamps=False
     ):
         """
-        flux,flux_err,chisq,DOF=_measure(X0, Y0, xmin, xmax, ymin, ymax, a, b, pa, allow_nan=True, stamps=False)
+        flux,flux_err,chisq,DOF=_numba_measure(X0, Y0, xmin, xmax, ymin, ymax, a, b, pa, allow_nan=True, stamps=False)
 
         or
 
-        flux,flux_err,chisq,DOF,data,model=_measure(X0, Y0, xmin, xmax, ymin, ymax, a, b,
+        flux,flux_err,chisq,DOF,data,model=_numba_measure(X0, Y0, xmin, xmax, ymin, ymax, a, b,
             pa, allow_nan=True, stamps=False)
 
         forced photometry for a single source

--- a/forced_phot/forced_phot.py
+++ b/forced_phot/forced_phot.py
@@ -404,6 +404,7 @@ class ForcedPhot:
         end = timer()
         print(f"Time to byte reorder: {end-start}s")
 
+        print(f"data mem usage: {self.data.nbytes/1024**2}")
         self.w = WCS(img_header, naxis=2).celestial
         self.pixelscale = (proj_plane_pixel_scales(self.w)[1] * u.deg).to(u.arcsec)
 

--- a/forced_phot/forced_phot.py
+++ b/forced_phot/forced_phot.py
@@ -366,21 +366,22 @@ class ForcedPhot:
         end = timer()
         
         print(f"Time to validate data: {end-start}s")
+        img_header = fi[0].header
         if not (
-            ("BMAJ" in fi[0].header.keys())
-            and ("BMIN" in fi[0].header.keys())
-            and ("BPA" in fi[0].header.keys())
+            ("BMAJ" in img_header.keys())
+            and ("BMIN" in img_header.keys())
+            and ("BPA" in img_header.keys())
         ):
 
             raise KeyError("Image header does not have BMAJ, BMIN, BPA keywords")
 
         start = timer()
-        self.BMAJ = fi[0].header["BMAJ"] * u.deg
-        self.BMIN = fi[0].header["BMIN"] * u.deg
-        self.BPA = fi[0].header["BPA"] * u.deg
+        self.BMAJ = img_header["BMAJ"] * u.deg
+        self.BMIN = img_header["BMIN"] * u.deg
+        self.BPA = img_header["BPA"] * u.deg
 
-        self.NAXIS1 = fi[0].header["NAXIS1"]
-        self.NAXIS2 = fi[0].header["NAXIS2"]
+        self.NAXIS1 = img_header["NAXIS1"]
+        self.NAXIS2 = img_header["NAXIS2"]
         end = timer()
         
         print(f"Time to initialise header info: {end-start}s")
@@ -403,7 +404,7 @@ class ForcedPhot:
         end = timer()
         print(f"Time to byte reorder: {end-start}s")
 
-        self.w = WCS(fi[0].header, naxis=2).celestial
+        self.w = WCS(img_header, naxis=2).celestial
         self.pixelscale = (proj_plane_pixel_scales(self.w)[1] * u.deg).to(u.arcsec)
 
     def _byte_reorder(self, arr):

--- a/forced_phot/forced_phot.py
+++ b/forced_phot/forced_phot.py
@@ -141,6 +141,15 @@ def get_kernel(
     fwhm_y: float,
     pa: float
     ):
+    """Calculate 2D Gaussian kernel, optimised with numba
+
+    Args:
+        x0 (float): the mean x coordinate (pixels)
+        y0 (float): the mean y coordinate (pixels)
+        fwhm_x (float): the FWHM in the x coordinate (pixels)
+        fwhm_y (float): the FWHM in the y coordinate (pixels)
+        pa (float): the position angle of the Gaussian (E of N) in deg
+    """
     
     pa = pa - pa_offset_deg
     
@@ -169,6 +178,17 @@ def get_kernel(
 
 @njit
 def _convolution(d, n, kernel):
+    """
+    Calculate the convolution of the data and noise with the kernel using numba.
+    
+    Args:
+        d: numpy array containing the background-subtracted data
+        n: numpy array containing the noise map
+        k: numpy array containing the kernel
+    
+    Returns:
+        Flux, error and chi-squared
+    """
     flux = ((d) * kernel / n ** 2).sum() / (kernel ** 2 / n ** 2).sum()
     flux_err = ((n) * kernel / n ** 2).sum() / (kernel / n ** 2).sum()
     chisq = (((d - kernel * flux) / n) ** 2).sum()
@@ -176,6 +196,12 @@ def _convolution(d, n, kernel):
 
 @njit
 def _meshgrid(xmin, xmax, ymin, ymax):
+    """
+    Generate a 2x2 meshgrid as required.
+    
+    With numba, this specific code is faster than the generalised np.meshgrid
+    """
+    
     x = np.arange(xmin, xmax)
     y = np.arange(ymin, ymax)
     

--- a/forced_phot/forced_phot.py
+++ b/forced_phot/forced_phot.py
@@ -136,45 +136,6 @@ specs = (
     float64,
     float64
 )
-
-
-
-def get_kernel_new(
-    x: np.ndarray, 
-    y: np.ndarray,
-    x0: float,
-    y0: float,
-    fwhm_x: float,
-    fwhm_y: float,
-    pa: float
-    ):
-    
-    pa = pa - pa_offset_deg
-    
-    self.x0 = x0
-    self.y0 = y0
-    self.fwhm_x = fwhm_x
-    self.fwhm_y = fwhm_y
-    # adjust the PA to agree with the selavy convention
-    # E of N
-    self.pa = pa - pa_offset
-    self.sigma_x = self.fwhm_x / 2 / np.sqrt(2 * np.log(2))
-    self.sigma_y = self.fwhm_y / 2 / np.sqrt(2 * np.log(2))
-
-    self.a = (
-        np.cos(self.pa) ** 2 / 2 / self.sigma_x ** 2
-        + np.sin(self.pa) ** 2 / 2 / self.sigma_y ** 2
-    )
-    self.b = (
-        np.sin(2 * self.pa) / 2 / self.sigma_x ** 2
-        - np.sin(2 * self.pa) / 2 / self.sigma_y ** 2
-    )
-    self.c = (
-        np.sin(self.pa) ** 2 / 2 / self.sigma_x ** 2
-        + np.cos(self.pa) ** 2 / 2 / self.sigma_y ** 2
-    )
-    
-
 @njit(specs)
 def get_kernel(
     x: np.ndarray, 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="forced_phot",
-    version="0.1.0",
+    version="0.2.0",
     description="Simple forced photometry on FITS images with optional source clustering.",
     author="David Kaplan",
     author_email="kaplan@uwm.edu",

--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,6 @@ setup(
         "scipy",
         "astropy",
         "pandas",
+        "numba"
     ],
 )


### PR DESCRIPTION
This PR:

1. Adds argument  FP.measure` to turn off cluster fitting
2. Adds `FP._numba_measure`, equivalent to `FP._measure` with numba optimisations
3. Removes the background data attribute as it is not used anywhere
4. Immediately load the data into memory rather than relying on lazy loading. This change is a tradeoff that makes sense for machines with poor I/O.

`FP._numba_measure` runs 10x as fast as `FP._measure`.

Disabling cluster fitting results in huge speedups (hard to quantify) for >5k sources, because 1) the clustering algorithm is slow for such large samples and 2) the fitting algorithm requires generating a complex kernel.